### PR TITLE
chore: unpin activesupport

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+### Metadata
+
+Links to relevant docs, related PRs or issues, etc.
+
+### Problem / Motivation
+
+Describe what the problem is or why the change is needed
+
+### Solution
+
+- [ ] CHANGELOG entry is added for code changes
+
+Describe how you are solving the problem
+
+### Testing
+
+Describe any interesting automated test changes
+
+Provide a test project yaml file, if relevant
+
+Provide any additional reproducing steps
+
+Show expected output / screenshot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 ### Fixes
 - Session path is project root, not first window root
+### Misc
+- Unpin activesupport as a development depenedency
 
 ## 3.2.1
 ### Enhancements

--- a/tmuxinator.gemspec
+++ b/tmuxinator.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |s|
   s.add_dependency "thor", "~> 1.3.0"
   s.add_dependency "xdg", "~> 2.2", ">= 2.2.5"
 
-  s.add_development_dependency "activesupport", "< 5.0.0" # Please see issue #432
   s.add_development_dependency "awesome_print", "~> 1.2"
   s.add_development_dependency "bundler", ">= 1.3"
   s.add_development_dependency "coveralls", "~> 0.8"


### PR DESCRIPTION
### Metadata

https://github.com/tmuxinator/tmuxinator/pull/433

### Problem / Motivation

activesupport was pinned to support Ruby < 2.2.3

We no longer support Ruby < 3.0, so this pin is no longer necessary

### Solution

- [X] CHANGELOG entry is added for code changes

Remove the pinned dev dependency

### Testing

In our CI pipeline. This change does not impact tmuxinator in runtime.